### PR TITLE
removing pip cache for the docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3-alpine
 
-RUN pip install gixy
+RUN pip install --no-cache-dir gixy
 
 CMD ["gixy"]


### PR DESCRIPTION
According to the alpine doc, no cache for package installation is a wished operation.